### PR TITLE
Update cycle_vote_sentinel.sh

### DIFF
--- a/cycle_vote_sentinel.sh
+++ b/cycle_vote_sentinel.sh
@@ -10,4 +10,5 @@
 
 for transaction in $(cat $1); do
     java -jar build/libs/nyzoVerifier-1.0.jar co.nyzo.verifier.scripts.CycleTransactionSignScript $transaction $2
+    sleep 7
 done


### PR DESCRIPTION
Add a waiting time after each for-loop to reduce error rate of batch voting. too many CTX votings in a short time overwhelms the verifier processing the request from sentinels ending up in unprocessed/missing votes. by adding a 7 second delay we get sure that a new verifier will process the next CTX votes in the sigs.txt